### PR TITLE
fix: reset polling attempts and clear timer

### DIFF
--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,9 +1,15 @@
 import { useEffect, useRef } from 'react';
 
-export function usePolling(fn: () => Promise<void>, intervalMs = 20000, maxAttempts = 3) {
+export function usePolling(
+  fn: () => Promise<void>,
+  intervalMs = 20_000,
+  maxAttempts = 3,
+) {
   const attempts = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
+    attempts.current = 0; // reset when deps change
     let cancelled = false;
 
     async function tick() {
@@ -14,12 +20,14 @@ export function usePolling(fn: () => Promise<void>, intervalMs = 20000, maxAttem
         cancelled = true; // stop on success
       } catch {
         // ignore and retry
-        setTimeout(tick, intervalMs);
+        timer.current = setTimeout(tick, intervalMs);
       }
     }
+
     tick();
     return () => {
       cancelled = true;
+      if (timer.current) clearTimeout(timer.current);
     };
   }, [fn, intervalMs, maxAttempts]);
 }


### PR DESCRIPTION
## Summary
- reset attempt counter on each start of usePolling
- clear outstanding timeouts when polling unmounts

## Testing
- `node node_modules/vitest/vitest.mjs` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689337d481548325908c018d7520a893